### PR TITLE
Initialize boot segment registers

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -15,16 +15,23 @@ message: db "Hello, World!", 0
 
 start:
   cli
+  xor ax, ax
+  mov ds, ax
+  mov es, ax
+  mov ss, ax
+  mov sp, 0x7C00
+  sti
+
   mov si, message
   mov ah, BIOS_FUNCTION_DISPLAY_CHAR
 
-  .putstr_loop
+  .putstr_loop:
     lodsb
     or al, al
       jz .end_putstr_loop
     int BIOS_FUNCTION
     jmp .putstr_loop
-  .end_putstr_loop
+  .end_putstr_loop:
 
   hlt
 


### PR DESCRIPTION
## Summary
- initialize DS, ES, SS, and SP before reading bootloader data or calling BIOS interrupts
- re-enable interrupts after stack setup
- add colons to local NASM labels to avoid assembler warnings

## Verification
- make clean
- make
- wc -c build/bootloader_binary.bin build/bootloader.img
- od -An -tx1 -j 510 -N 2 build/bootloader_binary.bin
- git diff --check