### PR TITLE
fix: remove stray shell token in clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ run-qemu: $(bootloader_image)
 
 .PHONY: clean
 clean:
-	rm -f $ $(bootloader_image)
+	rm -f $(bootloader_image)


### PR DESCRIPTION
## Summary
- Remove the stray `$` in the Makefile clean target.
- Use `rm -f $(bootloader_image)` so cleanup works as intended.

## Validation
- Ran `make clean` successfully to confirm the clean target expands and executes correctly.

## Issue
- Related finding: https://github.com/kitsuyui/kimono/issues/112
