### PR TITLE
Pin spellcheck workflow ref

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@a7071a4635eaece62696cd7132306616ce283c47


### PR DESCRIPTION
## Summary
- Pin the shared spellcheck reusable workflow to a specific commit SHA.
- Keep the existing pull request spellcheck job and read-only permissions unchanged.

## Validation
- git diff --check
- actionlint .github/workflows/spellcheck.yml
