### PR TITLE
Clear direction flag before using lodsb

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -20,6 +20,7 @@ start:
   mov es, ax
   mov ss, ax
   mov sp, 0x7C00
+  cld
   sti
 
   mov si, message


### PR DESCRIPTION
## Summary
- clear the x86 direction flag during bootloader initialization
- make the later `lodsb` string loop advance `SI` forward regardless of prior firmware state

## Validation
- `typos .`
- `git diff --check`

Build note:
- `make clean all` was not run locally because `nasm` is not installed in this environment.
