### PR TITLE
fix: move message data label after hlt to prevent boot-time instruction aliasing

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -11,8 +11,6 @@ bits 16
 %define BIOS_FUNCTION_DISPLAY_CHAR 0x0E
 %define BIOS_FUNCTION 0x10
 
-message: db "Hello, World!", 0
-
 start:
   cli
   xor ax, ax
@@ -34,6 +32,8 @@ start:
   .end_putstr_loop:
 
   hlt
+
+message: db "Hello, World!", 0
 
 times MBR_MAX_SIZE_BYTES - ($ - $$) db 0
 dw MBR_SIGNATURE


### PR DESCRIPTION
## Fix: move `message:` data label to after `hlt`

### What changed and why

The `message:` data label was positioned before `start:`, which placed the ASCII bytes of `"Hello, World!"` at offset 0x7C00 — the exact address BIOS jumps to on boot. This means the CPU executed the string's byte sequence as x86 instructions rather than as data.

The byte sequence starting at `"Hello, World!"` decodes as a series of real instructions. Notably, the bytes `0x6C 0x72 0x6C` ("lrl") decode as `insb` followed by `jb +0x6C`. The `insb` instruction reads from I/O port DX (whose value after BIOS POST is undefined); if the byte read falls in the range 0x00–0x1F, the subsequent `sub al, 0x20` sets CF=1, and `jb +0x6C` jumps forward to 0x7C77 — landing squarely in the zero-padding area and skipping `start:` entirely. In that scenario, the bootloader silently does nothing.

This is a real edge case, not a theoretical one: the behavior depends on the I/O port value at POST time, which varies by hardware and emulator.

### How the fix works

`message:` is moved to after the `hlt` instruction. The binary layout now places the `cli` instruction of `start:` at 0x7C00, exactly where BIOS expects execution to begin. The string data follows the code and is only ever reached as data (via `mov si, message`), never as instructions. The MBR padding and signature at the end of the 512-byte sector are unaffected.

### Verification

- The assembler produces a valid 512-byte MBR image (last two bytes `0x55 0xAA`).
- A hex dump of the output confirms that offset 0x7C00 now begins with `0xFA` (`cli`), not `0x48` (`H`).
- Booting the image in QEMU displays `Hello, World!` correctly on all tested runs.

### Trade-offs

None. Moving a data label out of the execution path is strictly correct behavior with no downside. Code size, functionality, and the MBR layout are all unchanged.
