### PR TITLE
fix: set video mode 3 before text output loop

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -9,7 +9,9 @@ bits 16
 %define MBR_SIGNATURE 0xAA55
 %define MBR_MAX_SIZE_BYTES 510
 %define BIOS_FUNCTION_DISPLAY_CHAR 0x0E
+%define BIOS_FUNCTION_SET_VIDEO_MODE 0x00
 %define BIOS_FUNCTION 0x10
+%define VIDEO_MODE_TEXT_80x25 0x03
 
 start:
   cli
@@ -20,6 +22,10 @@ start:
   mov sp, 0x7C00
   cld
   sti
+
+  mov ah, BIOS_FUNCTION_SET_VIDEO_MODE
+  mov al, VIDEO_MODE_TEXT_80x25
+  int BIOS_FUNCTION
 
   mov si, message
   mov ah, BIOS_FUNCTION_DISPLAY_CHAR


### PR DESCRIPTION
## Problem

The text output loop uses INT 10h/AH=0Eh (TTY write character) without first
explicitly setting a video mode. BIOS INT 10h TTY output depends on the active
video mode; if firmware does not initialize to text mode, output is silently
lost or corrupted.

BIOS typically boots into text mode (mode 3: 80×25 color), but this is
convention, not a guarantee. Some BIOS implementations and emulator
configurations may start in a graphics mode.

## Change

Add INT 10h/AH=00h (set video mode) with AL=03h (mode 3, 80×25 color text)
before the print loop. This makes the text-mode assumption explicit and ensures
portable output behavior across BIOS implementations.

Two named constants are introduced to document the values:
- `BIOS_FUNCTION_SET_VIDEO_MODE` (0x00)
- `VIDEO_MODE_TEXT_80x25` (0x03)

## Verification

- `make` succeeds; binary output remains exactly 512 bytes.
- The `times` padding recalculates automatically for the 4 additional bytes.
- String output loop logic is unchanged.
