### PR TITLE
fix: add .DELETE_ON_ERROR to prevent stale partial build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ sources = src/helloworld_bootloader.asm
 bootloader_binary = build/bootloader_binary.bin
 bootloader_image = build/bootloader.img
 
+.DELETE_ON_ERROR:
+
 .PHONY: all
 all: $(bootloader_image)
 


### PR DESCRIPTION
## Summary

The `$(bootloader_image)` target in the Makefile is built with two
sequential `dd` commands. If the process is interrupted between the
two commands (e.g., Ctrl+C, kill, or disk-full), `bootloader.img` is
left in a partial state — zero-filled from the first `dd` but without
the actual bootloader binary. Because the file already exists with a
timestamp newer than the source, `make` considers it up to date and
skips the rebuild on the next run, silently using a broken image.

## Change

Add `.DELETE_ON_ERROR:` to the Makefile. This built-in Make special
target instructs Make to delete a target file whenever its recipe exits
with a non-zero status or the build is interrupted by a signal. The
next `make` invocation will then detect the missing target and
rebuild from scratch.

## Test Plan

- [ ] Build succeeds: `make` completes without error
- [ ] Interrupt test: `make` then Ctrl+C mid-build; verify `build/bootloader.img` is removed
- [ ] Clean rebuild: `make clean && make` produces a valid image
