### PR TITLE
fix: restore AH register before each BIOS int 10h call in print loop

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -34,6 +34,7 @@ start:
     lodsb
     or al, al
       jz .end_putstr_loop
+    mov ah, BIOS_FUNCTION_DISPLAY_CHAR
     int BIOS_FUNCTION
     jmp .putstr_loop
   .end_putstr_loop:


### PR DESCRIPTION
## Summary

`int 10h/AH=0Eh` is used to output characters in a loop, but `AH` is only
set once before the loop begins. The BIOS specification does not guarantee
that INT 10h preserves `AH` across calls; some implementations overwrite it
(e.g. clear it to 0), which would cause subsequent iterations to invoke
`AH=0x00` (set video mode) instead of `AH=0x0E` (TTY output), corrupting
or stopping character output.

## Change

Add `mov ah, BIOS_FUNCTION_DISPLAY_CHAR` at the start of each loop
iteration so the function selector is unconditionally restored before every
`int BIOS_FUNCTION` call.

```diff
 .putstr_loop:
   lodsb
   or al, al
     jz .end_putstr_loop
+  mov ah, BIOS_FUNCTION_DISPLAY_CHAR
   int BIOS_FUNCTION
   jmp .putstr_loop
```

## Verification

- Assembled with NASM 3.01: `make` succeeds, output binary is 512 bytes.
- Adjacent static check: no ASM-specific linter available; build pass is the gate.

## Trade-offs

- **Pros**: Portable across BIOS implementations that clobber AH; 1-instruction change, zero impact on normal BIOS that preserves AH.
- **Cons**: None — `mov ah, imm8` is cheap and idempotent.
