### PR TITLE
chore: add lefthook to run local checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,18 @@ The build writes `build/bootloader_binary.bin` and `build/bootloader.img`.
 ```sh
 make run-qemu
 ```
+
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the hooks:
+
+```sh
+lefthook install
+```
+
+This sets up the following local checks that run before every commit and push:
+
+- **spellcheck** – runs `typos` to catch spelling mistakes, mirroring the `spellcheck` CI job.
+- **build** – assembles the bootloader with `make` (requires `nasm`) and then runs `make clean` to leave the tree clean.
+
+If either tool is not installed, the corresponding hook will fail. Install the missing tool or remove the relevant entry from `lefthook.yml` for your local setup.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+pre-commit:
+  commands:
+    spellcheck:
+      run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; typos"
+    build:
+      run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; make && make clean"
+
+pre-push:
+  commands:
+    spellcheck:
+      run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; typos"
+    build:
+      run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; make && make clean"


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with `pre-commit` and `pre-push` hooks that run two local checks: `typos` (spell-check) and `make && make clean` (assembler build).
- Add a `## Development` section to `README.md` explaining how to install lefthook and what each check does.

## Checks introduced

| Hook | Command | Purpose |
|------|---------|---------|
| `spellcheck` | `typos` | Mirrors the existing `spellcheck` CI job (crate-ci/typos) |
| `build` | `make && make clean` | Assembles the bootloader with NASM and cleans up artifacts |

Both hooks run on `pre-commit` and `pre-push`. The `make clean` step ensures no build artifacts are left in the working tree after the hook runs.

## Files changed

- `lefthook.yml` – new file defining the hooks
- `README.md` – new `## Development` section with setup instructions

## Test plan

- [ ] `lefthook install` succeeds
- [ ] `typos` passes with no errors on current source
- [ ] `make && make clean` builds cleanly and leaves the tree clean
- [ ] Pre-commit hook runs and passes on a test commit
