### PR TITLE
fix: remove VNC password flag and document display requirements for run-qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ $(bootloader_image): $(bootloader_binary)
 run-qemu: $(bootloader_image)
 	qemu-system-x86_64 \
 		-monitor stdio \
-		-vnc :0,password \
 		-drive file=$(bootloader_image),format=raw
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Building the bootloader requires these command-line tools:
 Running the image locally also requires:
 
 - `qemu-system-x86_64` to boot the generated image in QEMU.
+  QEMU must be built with a graphical display backend (such as SDL on Linux or Cocoa on macOS).
+  Headless environments without a display are not supported by `make run-qemu`.
 
 The project is known to build with NASM 3.01. No narrower minimum NASM
 version is declared.


### PR DESCRIPTION
The `run-qemu` Makefile target previously passed `-vnc :0,password` to QEMU,
which starts the VNC server in password-authentication mode. However, no
password-supply mechanism existed in the Makefile — users had to manually set
a password through the QEMU monitor after startup, a step not documented
anywhere.

## Changes

- **Makefile**: Remove the `-vnc :0,password` flag so QEMU uses its default
  graphical display backend (SDL on Linux, Cocoa on macOS). `make run-qemu`
  now works out of the box on a local desktop without additional steps.

- **README.md**: Document that `make run-qemu` requires a graphical display
  environment. This makes the dependency explicit rather than implicit, and
  clarifies that headless environments are not supported.

## Verification

```sh
make -n run-qemu
# qemu-system-x86_64 -monitor stdio -drive file=build/bootloader.img,format=raw
```

Dry-run confirms the correct invocation. Spellcheck passes. No other CI
targets exist for this project.

## Trade-offs

The previous `-vnc :0,password` option provided a remote-access path in theory,
but required a password-setup step that was not documented and blocked the
advertised `make run-qemu` workflow. Removing it trades that (broken) remote
access capability for a working local display experience that matches what the
README documents. Users who need VNC can pass the flag manually.
