### PR TITLE
fix: use halt loop to prevent resume into zero padding after interrupt

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -39,7 +39,9 @@ start:
     jmp .putstr_loop
   .end_putstr_loop:
 
+.halt:
   hlt
+  jmp .halt
 
 message: db "Hello, World!", 0
 


### PR DESCRIPTION
## Summary

Replace the bare `hlt` with a `.halt: hlt; jmp .halt` loop to prevent execution from falling through into the zero-padding region when an interrupt resumes the CPU.

## Problem

x86 `hlt` suspends the CPU until an interrupt arrives, then resumes at the **next** instruction. With interrupts enabled (`sti` was called earlier), a timer or other interrupt can fire and return to the instruction immediately after `hlt`. Previously that next instruction was the zero-padding byte sequence (`db 0` × N), where opcode `0x00` decodes as `add [bx+si], al`, causing unintended writes to memory.

The standard patterns to avoid this are:
- `cli; hlt` — disable interrupts, then halt (CPU stays halted)
- `.halt: hlt; jmp .halt` — loop back to `hlt` after any interrupt returns

## Change

```diff
-  hlt
+.halt:
+  hlt
+  jmp .halt
```

This adopts the loop form so the bootloader returns to the halted state after any interrupt is serviced, without suppressing interrupts entirely.

## Verification

- `make` builds cleanly with NASM.
- Collateral check: no violations.
