### PR TITLE
fix: initialize BH register to 0 before INT 10h teletype output

### DIFF
--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -29,6 +29,7 @@ start:
 
   mov si, message
   mov ah, BIOS_FUNCTION_DISPLAY_CHAR
+  xor bh, bh  ; INT 10h AH=0Eh expects BH=0 (video page 0)
 
   .putstr_loop:
     lodsb


### PR DESCRIPTION
## Summary

INT 10h AH=0Eh (teletype output) reads BH as the video page number.
The loop began with BH uninitialized after `xor ax, ax` cleared only AX,
so the page number depended on whatever value BH held after BIOS POST.
Most BIOSes and QEMU ignore BH or treat it as 0, so there is no observable
difference in the common case, but the code relied on an implicit assumption
rather than the documented register contract.

This change adds `xor bh, bh` immediately before the print loop to
set video page 0 explicitly.

## Changes

- `src/helloworld_bootloader.asm`: add `xor bh, bh` before the
  teletype loop to satisfy the INT 10h AH=0Eh register contract.

## Verification

- Assembles cleanly with `nasm -f bin` (no errors or warnings).
- No automated tests exist for this project; correctness is verified
  by running in QEMU (`make run-qemu`).