### PR TITLE
fix: add missing bootloader_binary to clean target and mkdir -p to build recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ bootloader_image = build/bootloader.img
 all: $(bootloader_image)
 
 $(bootloader_binary): $(sources)
+	mkdir -p build
 	nasm -f bin -o $(bootloader_binary) $(sources)
 
 $(bootloader_image): $(bootloader_binary)
@@ -22,4 +23,4 @@ run-qemu: $(bootloader_image)
 
 .PHONY: clean
 clean:
-	rm -f $(bootloader_image)
+	rm -f $(bootloader_image) $(bootloader_binary)


### PR DESCRIPTION
## Summary

- The `clean` target only removed `build/bootloader.img` but not `build/bootloader_binary.bin`.
  Running `make clean && make all` would skip a full clean rebuild of the intermediate binary.
- The `$(bootloader_binary)` recipe had no `mkdir -p build` step, creating an implicit dependency
  on the tracked `build/.gitignore` file to ensure the `build/` directory exists at checkout.

## Changes

- `Makefile`: add `$(bootloader_binary)` to the `clean` target
- `Makefile`: add `mkdir -p build` to the `$(bootloader_binary)` recipe so the directory is
  created explicitly by make

## Verification

`make clean` now removes both `build/bootloader.img` and `build/bootloader_binary.bin`.
The build directory is created by the recipe rather than relying on git checkout state.
