### PR TITLE
test: add a headless smoke check for boot output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 sources = src/helloworld_bootloader.asm
 bootloader_binary = build/bootloader_binary.bin
 bootloader_image = build/bootloader.img
+runtime_output = build/runtime-output.txt
 
 .DELETE_ON_ERROR:
 
@@ -20,6 +21,25 @@ run-qemu: $(bootloader_image)
 		-monitor stdio \
 		-drive file=$(bootloader_image),format=raw
 
+.PHONY: check
+check: $(bootloader_image)
+	mkdir -p build
+	rm -f $(runtime_output)
+	tmp_output="$$(mktemp)"; \
+	trap 'rm -f "$$tmp_output"' EXIT INT TERM; \
+	qemu-system-x86_64 \
+		-display none \
+		-monitor none \
+		-serial file:"$$tmp_output" \
+		-drive file=$(bootloader_image),format=raw \
+		-pidfile build/qemu.pid & \
+	qemu_pid=$$!; \
+	sleep 1; \
+	if kill -0 "$$qemu_pid" 2>/dev/null; then kill "$$qemu_pid" 2>/dev/null || true; fi; \
+	wait "$$qemu_pid" 2>/dev/null || true; \
+	mv "$$tmp_output" $(runtime_output); \
+	grep -F "Hello, World!" $(runtime_output)
+
 .PHONY: clean
 clean:
-	rm -f $(bootloader_image) $(bootloader_binary)
+	rm -f $(bootloader_image) $(bootloader_binary) $(runtime_output) build/qemu.pid

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Running the image locally also requires:
 - `qemu-system-x86_64` to boot the generated image in QEMU.
   QEMU must be built with a graphical display backend (such as SDL on Linux or Cocoa on macOS).
   Headless environments without a display are not supported by `make run-qemu`.
+  The automated smoke test uses QEMU headlessly and captures the same boot message through COM1.
 
 The project is known to build with NASM 3.01. No narrower minimum NASM
 version is declared.
@@ -44,6 +45,15 @@ The build writes `build/bootloader_binary.bin` and `build/bootloader.img`.
 make run-qemu
 ```
 
+## Runtime Smoke Test
+
+```sh
+make check
+```
+
+This boots the generated image in headless QEMU, captures the boot message from COM1,
+and fails unless `Hello, World!` is observed in the runtime output.
+
 ## Development
 
 Install [lefthook](https://github.com/evilmartians/lefthook) and register the hooks:
@@ -56,5 +66,6 @@ This sets up the following local checks that run before every commit and push:
 
 - **spellcheck** – runs `typos` to catch spelling mistakes, mirroring the `spellcheck` CI job.
 - **build** – assembles the bootloader with `make` (requires `nasm`) and then runs `make clean` to leave the tree clean.
+- **runtime smoke test** – runs `make check` to verify that the booted image emits `Hello, World!` through the automated QEMU observation path.
 
 If either tool is not installed, the corresponding hook will fail. Install the missing tool or remove the relevant entry from `lefthook.yml` for your local setup.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,8 @@ pre-commit:
       run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; typos"
     build:
       run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; make && make clean"
+    runtime-smoke-test:
+      run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; make check && make clean"
 
 pre-push:
   commands:
@@ -11,3 +13,5 @@ pre-push:
       run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; typos"
     build:
       run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; make && make clean"
+    runtime-smoke-test:
+      run: "for name in $(env | sed -n 's/^\\(GIT_[A-Za-z0-9_]*\\)=.*/\\1/p'); do unset \"$name\"; done; make check && make clean"

--- a/src/helloworld_bootloader.asm
+++ b/src/helloworld_bootloader.asm
@@ -12,6 +12,13 @@ bits 16
 %define BIOS_FUNCTION_SET_VIDEO_MODE 0x00
 %define BIOS_FUNCTION 0x10
 %define VIDEO_MODE_TEXT_80x25 0x03
+%define COM1_PORT 0x3F8
+%define COM1_INTERRUPT_ENABLE_PORT COM1_PORT + 1
+%define COM1_FIFO_CONTROL_PORT COM1_PORT + 2
+%define COM1_LINE_CONTROL_PORT COM1_PORT + 3
+%define COM1_MODEM_CONTROL_PORT COM1_PORT + 4
+%define COM1_LINE_STATUS_PORT COM1_PORT + 5
+%define COM1_LINE_STATUS_TRANSMIT_READY 0x20
 
 start:
   cli
@@ -27,6 +34,7 @@ start:
   mov al, VIDEO_MODE_TEXT_80x25
   int BIOS_FUNCTION
 
+  call initialize_serial
   mov si, message
   mov ah, BIOS_FUNCTION_DISPLAY_CHAR
   xor bh, bh  ; INT 10h AH=0Eh expects BH=0 (video page 0)
@@ -35,6 +43,7 @@ start:
     lodsb
     or al, al
       jz .end_putstr_loop
+    call write_serial_char
     mov ah, BIOS_FUNCTION_DISPLAY_CHAR
     int BIOS_FUNCTION
     jmp .putstr_loop
@@ -43,6 +52,52 @@ start:
 .halt:
   hlt
   jmp .halt
+
+initialize_serial:
+  mov dx, COM1_INTERRUPT_ENABLE_PORT
+  xor al, al
+  out dx, al
+
+  mov dx, COM1_LINE_CONTROL_PORT
+  mov al, 0x80
+  out dx, al
+
+  mov dx, COM1_PORT
+  mov al, 0x03
+  out dx, al
+
+  mov dx, COM1_INTERRUPT_ENABLE_PORT
+  xor al, al
+  out dx, al
+
+  mov dx, COM1_LINE_CONTROL_PORT
+  mov al, 0x03
+  out dx, al
+
+  mov dx, COM1_FIFO_CONTROL_PORT
+  mov al, 0xC7
+  out dx, al
+
+  mov dx, COM1_MODEM_CONTROL_PORT
+  mov al, 0x0B
+  out dx, al
+  ret
+
+write_serial_char:
+  push ax
+
+  .wait_for_transmit_ready:
+    mov dx, COM1_LINE_STATUS_PORT
+    in al, dx
+    test al, COM1_LINE_STATUS_TRANSMIT_READY
+    jz .wait_for_transmit_ready
+
+  pop ax
+  push ax
+  mov dx, COM1_PORT
+  out dx, al
+  pop ax
+  ret
 
 message: db "Hello, World!", 0
 


### PR DESCRIPTION
## Summary
- mirror the boot message to COM1 so the runtime path can be observed without a graphical QEMU session
- add a headless `make check` target that boots the image and asserts the expected serial output
- run the same runtime smoke test from lefthook so local commit/push checks cover the boot path

## Testing
- `make`
- `typos`
- `make check` (not run locally: `qemu-system-x86_64` is unavailable in this environment)
